### PR TITLE
Discourage use of snap to install docker

### DIFF
--- a/source/docker.rst
+++ b/source/docker.rst
@@ -1,7 +1,7 @@
 Using Docker with PufferPanel
 =============================
 
-First, install Docker on the node. Please follow Docker's installation instructions located at https://docs.docker.com/get-docker/
+First, install Docker on the node. Please follow Docker's installation instructions located at https://docs.docker.com/get-docker/. When using Ubuntu, do not install Docker using its snap package, as it will not have permission to write into `/var/lib/pufferpanel`. 
 
 Next, add the docker group (if not there) and add pufferpanel as a user of this group.
 


### PR DESCRIPTION
The snap package for Docker is incompatible with the default configuration of PufferPanel. Snapped Docker will only have read-only access to `/var/lib`, making the panel unable to mount this directory to run servers in.