### PR TITLE
Correct dialect field for PostgreSQL example

### DIFF
--- a/source/guides/database.rst
+++ b/source/guides/database.rst
@@ -46,7 +46,7 @@ PostgresSQL
   {
     "panel": {
       "database": {
-        "dialect": "postgres",
+        "dialect": "postgresql",
         "url": "user=pufferpanel password=pufferpanel dbname=pufferpanel port=9920 sslmode=disable"
       }
     }


### PR DESCRIPTION
The correct dialect is "postgresql" as shown [here](https://github.com/PufferPanel/PufferPanel/blob/1c675b6fd3e46e1b4550d0d19681fcf633a12c42/database/loader.go#L77)