### PR TITLE
Add docker-compose configuration to "Installing PufferPanel using Docker" documentation

### DIFF
--- a/source/installing-docker.rst
+++ b/source/installing-docker.rst
@@ -7,6 +7,8 @@ We recommend using *latest* as it contains everything you will need to get serve
 Creating the container
 ----------------------
 
+**Via command line**
+
 To create the container, start it, and add the default user:
 
 .. code-block:: bash
@@ -16,8 +18,42 @@ To create the container, start it, and add the default user:
     $ docker create --name pufferpanel -p 8080:8080 -p 5657:5657 -v pufferpanel-config:/etc/pufferpanel -v /var/lib/pufferpanel:/var/lib/pufferpanel -v /var/run/docker.sock:/var/run/docker.sock --restart=on-failure pufferpanel/pufferpanel:latest
     $ docker start pufferpanel
     $ docker exec -it pufferpanel /pufferpanel/pufferpanel user add
-    
+
 And you're done. Your panel is now accessible at http://localhost:8080
+
+**Via Docker Compose**
+
+You will need the Docker Compose plugin installed on your system.
+
+Create the Pufferpanel directory: 
+
+.. code-block:: bash
+    $ mkdir -p /var/lib/pufferpanel
+
+Create the following ``docker-compose.yml`` file which defines the Pufferpanel service, including its ports and volume mappings. This is equivalent to the command line setup above. 
+
+.. code-block:: yml
+
+    version: '3.2'
+    services:
+      pufferpanel:
+        image: pufferpanel/pufferpanel:latest # See "Tags" for other images
+        restart: on-failure
+        ports:
+          - 8080:8080 # XXXX:8080, where XXXX on the outside will be sent to 8080 inside the container
+          - 5657:5657 # YYYY:5657
+        volumes:
+          - ./pufferpanel-config:/etc/pufferpanel
+          - /var/lib/pufferpanel:/var/lib/pufferpanel
+          - /var/run/docker.sock:/var/run/docker.sock
+
+Start the container and add the default user:
+
+.. code-block:: bash
+    $ docker compose up -d
+    $ docker exec -it pufferpanel /pufferpanel/pufferpanel user add
+
+And you're done. Your panel is now accessible at http://localhost:XXXX (where XXXX is 8080 as defined above).
 
 
 Understanding the config

--- a/source/installing-docker.rst
+++ b/source/installing-docker.rst
@@ -46,9 +46,13 @@ Create the following ``docker-compose.yml`` file which defines the Pufferpanel s
           - 8080:8080 # XXXX:8080, where port XXXX on the outside (host) will be sent to 8080 inside the container
           - 5657:5657 # YYYY:5657
         volumes:
-          - ./pufferpanel-config:/etc/pufferpanel
+          - pufferpanel-config:/etc/pufferpanel
           - /var/lib/pufferpanel:/var/lib/pufferpanel
           - /var/run/docker.sock:/var/run/docker.sock
+    
+    volumes:
+      pufferpanel-config: # Creates a named volume, referenced above
+        external: false
 
 Start the container and add the default user:
 

--- a/source/installing-docker.rst
+++ b/source/installing-docker.rst
@@ -28,6 +28,7 @@ You will need the Docker Compose plugin installed on your system.
 Create the Pufferpanel directory: 
 
 .. code-block:: bash
+
     $ mkdir -p /var/lib/pufferpanel
 
 Create the following ``docker-compose.yml`` file which defines the Pufferpanel service, including its ports and volume mappings. This is equivalent to the command line setup above. 
@@ -40,7 +41,7 @@ Create the following ``docker-compose.yml`` file which defines the Pufferpanel s
         image: pufferpanel/pufferpanel:latest # See "Tags" for other images
         restart: on-failure
         ports:
-          - 8080:8080 # XXXX:8080, where XXXX on the outside will be sent to 8080 inside the container
+          - 8080:8080 # XXXX:8080, where port XXXX on the outside (host) will be sent to 8080 inside the container
           - 5657:5657 # YYYY:5657
         volumes:
           - ./pufferpanel-config:/etc/pufferpanel
@@ -50,6 +51,7 @@ Create the following ``docker-compose.yml`` file which defines the Pufferpanel s
 Start the container and add the default user:
 
 .. code-block:: bash
+
     $ docker compose up -d
     $ docker exec -it pufferpanel /pufferpanel/pufferpanel user add
 

--- a/source/installing-docker.rst
+++ b/source/installing-docker.rst
@@ -21,6 +21,8 @@ To create the container, start it, and add the default user:
 
 And you're done. Your panel is now accessible at http://localhost:8080
 
+----
+
 **Via Docker Compose**
 
 You will need the Docker Compose plugin installed on your system.


### PR DESCRIPTION
I use compose files for my docker setups as I find they're easier to manage, which is what I did for my Pufferpanel setup. Provided in this documentation update is my compose file and equivalent instructions.

Summary of changes:
- Separate installation as "command line" and "docker compose"
- Include modified instructions of CLI install in the Compose section
- Create a docker-compose example file with relevant comments to guide user