### PR TITLE
Add Debian 12 and Raspberry Pi OS/Raspbian 12 (Bookworm) to Supported Operating Systems (Update installing.rst)

### DIFF
--- a/source/installing.rst
+++ b/source/installing.rst
@@ -22,9 +22,13 @@ System Requirements
 +------------------------+-------+-------+-------+
 | Debian Bullseye (11)   | Yes   | Yes   | No    |
 +------------------------+-------+-------+-------+
+| Debian Bookworm (12)   | Yes   | Yes   | No    |
++------------------------+-------+-------+-------+
 | Raspbian Buster (10)   | No    | Yes   | Yes   |
 +------------------------+-------+-------+-------+
 | Raspbian Bullseye (11) | No    | Yes   | Yes   |
++------------------------+-------+-------+-------+
+| Raspbian Bookworm (12) | No    | Yes   | Yes   |
 +------------------------+-------+-------+-------+
 
 * If your operating system is not listed above take a look at :ref:`this<unsupportedos>`


### PR DESCRIPTION
This PR adds Debian 12 and Raspberry Pi OS/Raspbian 12 to the supported operating systems list in the installing part of the documentation. Bookworm is already out for a while now, and PufferPanel is available as official package (amd64 and aarch64) for Bookworm ever since PufferPanel v2.7 got released.