### PR TITLE
 content(v2): Improve installing-docker.rst

### DIFF
--- a/source/installing-docker.rst
+++ b/source/installing-docker.rst
@@ -6,23 +6,66 @@ Installing PufferPanel using Docker
    The Docker image is currently X86_64 only due to limitations in the Github Actions infrastructure.
 
 PufferPanel offers several images that include dependencies needed to run game servers. 
-We recommend using *latest* as it contains everything you will need to get servers runing quickly.
+We recommend using *latest* as it contains everything you will need to get servers running quickly.
 
-Creating the container
-----------------------
+Creating volumes
+----------------
 
-To create the container, start it, and add the default user:
+Before creating the container, you need to create two Docker volumes: one for configuration and one for game data.
+
+Volumes ensure that your PufferPanel configuration and game server data are preserved even if the container is recreated or updated. 
+Without them, all files stored inside the container would be lost. 
+With volumes, your settings, game servers, and files persist across upgrades and restarts.
+
+To create the config and data volumes use the following commands:
 
 .. code-block:: bash
 
-    $ mkdir -p /var/lib/pufferpanel
     $ docker volume create pufferpanel-config
-    $ docker create --name pufferpanel -p 8080:8080 -p 5657:5657 -v pufferpanel-config:/etc/pufferpanel -v /var/lib/pufferpanel:/var/lib/pufferpanel -v /var/run/docker.sock:/var/run/docker.sock --restart=on-failure pufferpanel/pufferpanel:latest
-    $ docker start pufferpanel
-    $ docker exec -it pufferpanel /pufferpanel/pufferpanel user add
-    
-And you're done. Your panel is now accessible at http://localhost:8080
+    $ docker volume create pufferpanel-data
 
+Creating the container
+----------------------
+Once the volumes are ready, create your container.
+
+Keep in mind that If you want your servers to be accessible from outside the host machine, you must bind the ports 
+to the host using the -p host_port:container_port option.
+
+.. code-block:: bash
+
+    $ docker create --name pufferpanel \
+        -p 8080:8080 -p 5657:5657 \
+        -v pufferpanel-config:/etc/pufferpanel \
+        -v pufferpanel-data:/var/lib/pufferpanel \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --restart=on-failure \
+        pufferpanel/pufferpanel:latest
+    
+- 8080:8080 → exposes the PufferPanel web UI (required, so you can access the web UI)
+- 5657:5657 → daemon port used by PufferPanel (optional, only needed if other machines should connect to this daemon)
+- Add more -p host:container pairs for any game server ports you want reachable from outside
+
+Start the container
+-------------------
+Once the container is created you can start it by running the following command:
+
+.. code-block:: bash
+
+    $ docker start pufferpanel
+
+Add user to the container
+-------------------------
+Finally, create an admin user to manage PufferPanel:
+
+.. code-block:: bash
+
+    $ docker exec -it pufferpanel /pufferpanel/pufferpanel user add
+
+Congratulations! 🎉
+
+Your PufferPanel instance is now up and running.
+
+You can access the web interface at: http://localhost:8080
 
 Understanding the config
 ------------------------

--- a/source/installing-docker.rst
+++ b/source/installing-docker.rst
@@ -42,8 +42,9 @@ to the host using the -p host_port:container_port option.
         pufferpanel/pufferpanel:latest
     
 - 8080:8080 → exposes the PufferPanel web UI (required, so you can access the web UI)
-- 5657:5657 → daemon port used by PufferPanel (optional, only needed if other machines should connect to this daemon)
+- 5657:5657 → SFTP port used by PufferPanel (optional but recommended: used to allow file transfers such as when `importing a minecraft server <https://docs.pufferpanel.com/en/2.x/guides/import-minecraft-server.html>`_)
 - Add more -p host:container pairs for any game server ports you want reachable from outside
+
 
 Start the container
 -------------------

--- a/source/installing-docker.rst
+++ b/source/installing-docker.rst
@@ -8,43 +8,56 @@ Installing PufferPanel using Docker
 PufferPanel offers several images that include dependencies needed to run game servers. 
 We recommend using *latest* as it contains everything you will need to get servers running quickly.
 
-Creating volumes
-----------------
+.. warning:: 
+    Be aware that if you are running a Linux distribution that enforces SELinux by default, you will run into issues
+    when creating a server that runs in its own docker container, as opposed to running on the PufferPanel container.
 
-Before creating the container, you need to create two Docker volumes: one for configuration and one for game data.
+    In these situations, you can:
 
-Volumes ensure that your PufferPanel configuration and game server data are preserved even if the container is recreated or updated. 
-Without them, all files stored inside the container would be lost. 
-With volumes, your settings, game servers, and files persist across upgrades and restarts.
+    - Disable SELinux.
+    - Configure SELinux to allow the PufferPanel container to spawn other containers.
+    - Avoid using game servers running on their own containers, (e.g., use the ``minecraft-vanilla`` template instead of ``minecraft-vanilla-docker``).
 
-To create the config and data volumes use the following commands:
+Creating mounting points
+-------------------------
+
+Before creating the container, you need to create mounting points to ensure your PufferPanel configuration 
+and game server data are preserved even if the container is recreated or updated. 
+
+With them, your settings, game servers, and files persist across upgrades and restarts.
+
+To create the config and data mounting points use the following commands:
 
 .. code-block:: bash
 
-    $ docker volume create pufferpanel-config
-    $ docker volume create pufferpanel-data
+    $ sudo mkdir -p /var/lib/pufferpanel
+    $ sudo docker volume create pufferpanel-config
 
 Creating the container
 ----------------------
-Once the volumes are ready, create your container.
+Once the mounting points are ready, create your container.
 
-Keep in mind that If you want your servers to be accessible from outside the host machine, you must bind the ports 
-to the host using the -p host_port:container_port option.
+Keep in mind that if you want your servers to be accessible from outside the host machine, you must bind the ports 
+to the host using the ``-p host_port:container_port`` option.
 
 .. code-block:: bash
 
-    $ docker create --name pufferpanel \
+    $ sudo docker create --name pufferpanel \
         -p 8080:8080 -p 5657:5657 \
         -v pufferpanel-config:/etc/pufferpanel \
-        -v pufferpanel-data:/var/lib/pufferpanel \
+        -v /var/lib/pufferpanel:/var/lib/pufferpanel:z \
         -v /var/run/docker.sock:/var/run/docker.sock \
         --restart=on-failure \
         pufferpanel/pufferpanel:latest
     
 - 8080:8080 → exposes the PufferPanel web UI (required, so you can access the web UI)
-- 5657:5657 → SFTP port used by PufferPanel (optional but recommended: used to allow file transfers such as when `importing a minecraft server <https://docs.pufferpanel.com/en/2.x/guides/import-minecraft-server.html>`_)
-- Add more -p host:container pairs for any game server ports you want reachable from outside
+- 5657:5657 → SFTP port used by PufferPanel (required, to allow file transfers, such as for example, when :doc:`Import Minecraft Servers <guides/import-minecraft-server>`)
+- Add more ``-p host:container`` pairs for any game server ports you want reachable from outside
 
+.. note::
+
+    If you later need to open more ports for other game server, you can remove the container using
+    ``sudo docker container rm pufferpanel`` and create a new one using the previous command with the new port configurations.
 
 Start the container
 -------------------
@@ -52,7 +65,7 @@ Once the container is created you can start it by running the following command:
 
 .. code-block:: bash
 
-    $ docker start pufferpanel
+    $ sudo docker start pufferpanel
 
 Add user to the container
 -------------------------
@@ -60,7 +73,7 @@ Finally, create an admin user to manage PufferPanel:
 
 .. code-block:: bash
 
-    $ docker exec -it pufferpanel /pufferpanel/pufferpanel user add
+    $ sudo docker exec -it pufferpanel /pufferpanel/pufferpanel user add
 
 Congratulations! 🎉
 


### PR DESCRIPTION
During my setup of PufferPanel using Docker, I ran into permission issues when following the instructions that suggested binding host folders directly for config and server data. This forced me to change the permissions of the created folder to get PufferPanel running.

Additionally, the instructions about port bindings weren’t very clear to me at first. For my use case, exposing the daemon port (5657) externally was not necessary, and keeping it closed improves security.

This PR attempts to clarify these points and make the Docker setup more reliable:

- Switches to Docker volumes (pufferpanel-config and pufferpanel-data) instead of host folders, preventing permission problems and ensuring persistent data.
- Clarifies which ports need to be exposed and provides guidance for binding additional ports for game servers created in the panel.
