### PR TITLE
fix build warnings

### DIFF
--- a/source/about/team.rst
+++ b/source/about/team.rst
@@ -11,13 +11,13 @@ PufferPanel started out as a custom solution for a small Minecraft Host, but qui
 +----------------------------------------------------------------+------------------------------------------------------------------------+-------------------+
 | .. image::                                                     | puffrfish                                                              | Founder           |
 |    http://gravatar.com/avatar/b1941b2071903182dcc47598d8d10fad |                                                                        |                   |
-|                                                                | `GitHub <https://github.com/puffrfish>`_                               |                   |
+|                                                                | `GitHub <https://github.com/puffrfish>`__                              |                   |
 +----------------------------------------------------------------+------------------------------------------------------------------------+-------------------+
 | .. image::                                                     | Joshua Taylor                                                          | Head Developer    |
 |    http://gravatar.com/avatar/edde31fa49f872ee344765c6707f5291 |                                                                        |                   |
-|                                                                | `GitHub <https://github.com/LordRalex>`_                               |                   |
+|                                                                | `GitHub <https://github.com/LordRalex>`__                              |                   |
 +----------------------------------------------------------------+------------------------------------------------------------------------+-------------------+
 | .. image::                                                     | nepcore                                                                | UI Developer      |
 |    http://gravatar.com/avatar/cf5459651ecb0d2ba21cd30d57ecf878 |                                                                        |                   |
-|                                                                | `GitHub <https://github.com/nepcore>`_                                 |                   |
+|                                                                | `GitHub <https://github.com/nepcore>`__                                |                   |
 +----------------------------------------------------------------+------------------------------------------------------------------------+-------------------+

--- a/source/migrate.rst
+++ b/source/migrate.rst
@@ -71,7 +71,7 @@ Run the following to update the panel:
       systemctl restart pufferpanel
 
 Stop Nodes
-^^^^
+^^^^^^^^^^
 
 On each node, run `systemctl stop pufferpanel`
 


### PR DESCRIPTION
Minor fix which resolved the following warnings during build:

```txt
WARNING: Duplicate explicit target name: "github". [docutils]
WARNING: Title underline too short.
```

Hyperlink was creating a named reference due to single `_`. See docs https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#hyperlinks

> Use two trailing underscores when embedding the URL. Technically, a single underscore works as well, but that would create a named reference instead of an anonymous one. Named references typically do not have a benefit when the URL is embedded. Moreover, they have the disadvantage that you must make sure that you do not use the same “Link text” for another link in your document.