### PR TITLE
Fix command syntax for adding APT repository

### DIFF
--- a/source/installing.rst
+++ b/source/installing.rst
@@ -63,7 +63,7 @@ For easiest installation, if you have one of the listed supported distributions,
 
    .. code-block:: bash
 
-      echo "deb https://packagecloud.io/pufferpanel/pufferpanel/any/ any main" > sudo tee /etc/apt/sources.list.d/pufferpanel.list
+      echo "deb https://packagecloud.io/pufferpanel/pufferpanel/any/ any main" | sudo tee /etc/apt/sources.list.d/pufferpanel.list
       sudo apt update
       sudo apt-get install pufferpanel
 


### PR DESCRIPTION
It might be a system issue, since I was testing this on WSL, using just debian. 

I was only able to get tee to work when I use the pipeline | instead of the  redirect operator > .
