### PR TITLE
Update DD_VERSION to 3.4.0 in common-problems.rst

### DIFF
--- a/source/guides/common-problems.rst
+++ b/source/guides/common-problems.rst
@@ -49,7 +49,7 @@ This is due to the version of “Depot Downloader” in use being outdated, even
 
 .. code-block:: console
     
-    export DD_VERSION=3.1.0
+    export DD_VERSION=3.4.0
     curl https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_$DD_VERSION/DepotDownloader-linux-x64.zip -L -o /tmp/dd.zip
     unzip /tmp/dd.zip -d /tmp/dd
     rm /var/lib/pufferpanel/binaries/depotdownloader/DepotDownloader


### PR DESCRIPTION
Depot Downloader's latest release version is 3.4.0 - this changes the docs to reflect that.