### PR TITLE
Migration Docs v2-v3: Clarify that failing to stop old nodes will result in a failure to log in

### DIFF
--- a/source/migrate.rst
+++ b/source/migrate.rst
@@ -75,6 +75,7 @@ Stop Nodes
 
 On each node, run `systemctl stop pufferpanel`
 
+**Note that if any old nodes are left running you will not be able to log into the panel to download the configuration files necessary to update them.**
 
 Deploy New Configs
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This addresses an issue I ran into while migrating from v2 to v3, where by not following the steps in the exact order I ended up being unable to log into the panel and requesting support:
<img width="445" height="505" alt="image" src="https://github.com/user-attachments/assets/f7171e22-3e40-4cae-965b-df6a5e94ec19" />
To ensure that nobody else burdens the support channel by making the same mistake, I believe that this disclaimer is a helpful addition. Wording can be changed, but as it's just a migration outline not much scrutiny should be necessary.
I think this would've helped me.