### PR TITLE
Fix some small errors in the documentation

### DIFF
--- a/source/migrate.rst
+++ b/source/migrate.rst
@@ -33,7 +33,7 @@ Install new repository
 
    .. code-block:: bash
 
-      echo "deb https://packagecloud.io/pufferpanel/pufferpanel/any/ any main" > sudo tee /etc/apt/sources.list.d/pufferpanel.list
+      echo "deb https://packagecloud.io/pufferpanel/pufferpanel/any/ any main" | sudo tee /etc/apt/sources.list.d/pufferpanel.list
       sudo apt update
 
 .. tab:: Red-Hat - Manual Repo

--- a/source/templates/templates.rst
+++ b/source/templates/templates.rst
@@ -40,7 +40,7 @@ The run section defines what happens when the start and stop buttons are pressed
 
 * **stop** - Command to send to the console of the running server to stop it
 * **pre** - Processors to run before the server starts
-* **post** - Processors to run after the server starts
+* **post** - Processors to run after the server exits
 * **command** - Command to run that runs the actual server
 * **environmentVars** - Any environment variables to set for this server
 


### PR DESCRIPTION
Fixes the following issues:

- The template documentation was not properly mentioning that `post` is executed after the server exists.
- The v2 to v3 migration guide tried to use bash redirection (`>`) with the `tee` command, which does not work.